### PR TITLE
refactor: added text and div tags to check-result

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
           </p>
           <div class="inputs-row">
             <div class="input-fields">
-              <div>
+              <div class="label">
                 <label for="foreground-color">Foreground color</label>
               </div>
               <div class="input-items">
@@ -34,7 +34,7 @@
               </div>
             </div>
             <div class="input-fields">
-              <div>
+              <div class="label">
                 <label for="background-color">Background color</label>
               </div>
               <div class="input-items">
@@ -55,128 +55,145 @@
               </div>
             </div>
             <div class="check-result">
-              <div>
-                <p class="text-small">Small Text</p>
-                <div class="pass">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlns:xlink="http://www.w3.org/1999/xlink"
-                    width="30px"
-                    height=""
-                    viewBox="0 -4 30 30"
-                    version="1.1"
-                  >
-                    <defs>
-                      <linearGradient
-                        x1="50%"
-                        y1="0%"
-                        x2="50%"
-                        y2="100%"
-                        id="linearGradient-1"
-                      >
-                        <stop stop-color="#1DD47F" offset="0%" />
-                        <stop stop-color="#0DA949" offset="100%" />
-                      </linearGradient>
-                    </defs>
-                    <g
-                      stroke="none"
-                      stroke-width="1"
-                      fill="none"
-                      fill-rule="evenodd"
+              <p class="text-small">Small Text</p>
+              <div class="circle-block">
+                <div>
+                  <p class="text-small">AA+</p>
+                  <div class="pass">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                      width="30px"
+                      height=""
+                      viewBox="0 -4 30 30"
+                      version="1.1"
                     >
+                      <defs>
+                        <linearGradient
+                          x1="50%"
+                          y1="0%"
+                          x2="50%"
+                          y2="100%"
+                          id="linearGradient-1"
+                        >
+                          <stop stop-color="#1DD47F" offset="0%" />
+                          <stop stop-color="#0DA949" offset="100%" />
+                        </linearGradient>
+                      </defs>
                       <g
-                        id="ui-gambling-website-lined-icnos-casinoshunter"
-                        transform="translate(-735.000000, -1911.000000)"
-                        fill="url(#linearGradient-1)"
-                        fill-rule="nonzero"
+                        stroke="none"
+                        stroke-width="1"
+                        fill="none"
+                        fill-rule="evenodd"
                       >
-                        <g transform="translate(50.000000, 1871.000000)">
-                          <path
-                            d="M714.442949,40.6265241 C715.185684,41.4224314 715.185684,42.6860985 714.442949,43.4820059 L697.746773,61.3734759 C697.314529,61.8366655 696.704235,62.0580167 696.097259,61.9870953 C695.539848,62.0082805 694.995328,61.7852625 694.600813,61.3625035 L685.557051,51.6712906 C684.814316,50.8753832 684.814316,49.6117161 685.557051,48.8158087 C686.336607,47.9804433 687.631056,47.9804433 688.410591,48.8157854 L696.178719,57.1395081 L711.589388,40.6265241 C712.368944,39.7911586 713.663393,39.7911586 714.442949,40.6265241 Z"
-                          />
+                        <g
+                          id="ui-gambling-website-lined-icnos-casinoshunter"
+                          transform="translate(-735.000000, -1911.000000)"
+                          fill="url(#linearGradient-1)"
+                          fill-rule="nonzero"
+                        >
+                          <g transform="translate(50.000000, 1871.000000)">
+                            <path
+                              d="M714.442949,40.6265241 C715.185684,41.4224314 715.185684,42.6860985 714.442949,43.4820059 L697.746773,61.3734759 C697.314529,61.8366655 696.704235,62.0580167 696.097259,61.9870953 C695.539848,62.0082805 694.995328,61.7852625 694.600813,61.3625035 L685.557051,51.6712906 C684.814316,50.8753832 684.814316,49.6117161 685.557051,48.8158087 C686.336607,47.9804433 687.631056,47.9804433 688.410591,48.8157854 L696.178719,57.1395081 L711.589388,40.6265241 C712.368944,39.7911586 713.663393,39.7911586 714.442949,40.6265241 Z"
+                            />
+                          </g>
                         </g>
                       </g>
-                    </g>
-                  </svg>
+                    </svg>
+                  </div>
                 </div>
-                <div class="pass">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlns:xlink="http://www.w3.org/1999/xlink"
-                    width="30px"
-                    height=""
-                    viewBox="0 -4 30 30"
-                  >
-                    <defs>
-                      <linearGradient x1="50%" y1="0%" x2="50%" y2="100%">
-                        <stop stop-color="#1DD47F" offset="0%" />
-                        <stop stop-color="#0DA949" offset="100%" />
-                      </linearGradient>
-                    </defs>
-                    <g
-                      stroke="none"
-                      stroke-width="1"
-                      fill="none"
-                      fill-rule="evenodd"
+                <div>
+                  <p class="text-small">AAA+</p>
+                  <div class="pass">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                      width="30px"
+                      height=""
+                      viewBox="0 -4 30 30"
                     >
+                      <defs>
+                        <linearGradient x1="50%" y1="0%" x2="50%" y2="100%">
+                          <stop stop-color="#1DD47F" offset="0%" />
+                          <stop stop-color="#0DA949" offset="100%" />
+                        </linearGradient>
+                      </defs>
                       <g
-                        transform="translate(-735.000000, -1911.000000)"
-                        fill="url(#linearGradient-1)"
-                        fill-rule="nonzero"
+                        stroke="none"
+                        stroke-width="1"
+                        fill="none"
+                        fill-rule="evenodd"
                       >
-                        <g transform="translate(50.000000, 1871.000000)">
-                          <path
-                            d="M714.442949,40.6265241 C715.185684,41.4224314 715.185684,42.6860985 714.442949,43.4820059 L697.746773,61.3734759 C697.314529,61.8366655 696.704235,62.0580167 696.097259,61.9870953 C695.539848,62.0082805 694.995328,61.7852625 694.600813,61.3625035 L685.557051,51.6712906 C684.814316,50.8753832 684.814316,49.6117161 685.557051,48.8158087 C686.336607,47.9804433 687.631056,47.9804433 688.410591,48.8157854 L696.178719,57.1395081 L711.589388,40.6265241 C712.368944,39.7911586 713.663393,39.7911586 714.442949,40.6265241 Z"
-                          />
+                        <g
+                          transform="translate(-735.000000, -1911.000000)"
+                          fill="url(#linearGradient-1)"
+                          fill-rule="nonzero"
+                        >
+                          <g transform="translate(50.000000, 1871.000000)">
+                            <path
+                              d="M714.442949,40.6265241 C715.185684,41.4224314 715.185684,42.6860985 714.442949,43.4820059 L697.746773,61.3734759 C697.314529,61.8366655 696.704235,62.0580167 696.097259,61.9870953 C695.539848,62.0082805 694.995328,61.7852625 694.600813,61.3625035 L685.557051,51.6712906 C684.814316,50.8753832 684.814316,49.6117161 685.557051,48.8158087 C686.336607,47.9804433 687.631056,47.9804433 688.410591,48.8157854 L696.178719,57.1395081 L711.589388,40.6265241 C712.368944,39.7911586 713.663393,39.7911586 714.442949,40.6265241 Z"
+                            />
+                          </g>
                         </g>
                       </g>
-                    </g>
-                  </svg>
+                    </svg>
+                  </div>
                 </div>
               </div>
             </div>
             <div class="check-result">
-              <div>
-                <p class="text-small">Large Text</p>
-                <div class="fail">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlns:xlink="http://www.w3.org/1999/xlink"
-                    version="1.1"
-                    width="30px"
-                    height="auto"
-                    viewBox="0 0 511.999 511.999"
-                    style="enable-background: new 0 0 511.999 511.999"
-                    xml:space="preserve"
-                  >
-                    <path
-                      style="fill: #ff6465"
-                      d="M384.955,256l120.28-120.28c9.019-9.019,9.019-23.642,0-32.66L408.94,6.765  c-9.019-9.019-23.642-9.019-32.66,0l-120.28,120.28L135.718,6.765c-9.019-9.019-23.642-9.019-32.66,0L6.764,103.058  c-9.019,9.019-9.019,23.642,0,32.66l120.28,120.28L6.764,376.28c-9.019,9.019-9.019,23.642,0,32.66l96.295,96.294  c9.019,9.019,23.642,9.019,32.66,0l120.28-120.28l120.28,120.28c9.019,9.019,23.642,9.019,32.66,0l96.295-96.294  c9.019-9.019,9.019-23.642,0-32.66L384.955,256z"
-                    />
-                  </svg>
+              <p class="text-small">Large Text</p>
+              <div class="circle-block">
+                <div>
+                  <p class="text-small">AA+</p>
+                  <div class="fail">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                      version="1.1"
+                      width="30px"
+                      height="auto"
+                      viewBox="0 0 511.999 511.999"
+                      style="enable-background: new 0 0 511.999 511.999"
+                      xml:space="preserve"
+                    >
+                      <path
+                        style="fill: #ff6465"
+                        d="M384.955,256l120.28-120.28c9.019-9.019,9.019-23.642,0-32.66L408.94,6.765  c-9.019-9.019-23.642-9.019-32.66,0l-120.28,120.28L135.718,6.765c-9.019-9.019-23.642-9.019-32.66,0L6.764,103.058  c-9.019,9.019-9.019,23.642,0,32.66l120.28,120.28L6.764,376.28c-9.019,9.019-9.019,23.642,0,32.66l96.295,96.294  c9.019,9.019,23.642,9.019,32.66,0l120.28-120.28l120.28,120.28c9.019,9.019,23.642,9.019,32.66,0l96.295-96.294  c9.019-9.019,9.019-23.642,0-32.66L384.955,256z"
+                      />
+                    </svg>
+                  </div>
                 </div>
-                <div class="fail">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    xmlns:xlink="http://www.w3.org/1999/xlink"
-                    width="30px"
-                    height="auto"
-                    viewBox="0 0 511.999 511.999"
-                    style="enable-background: new 0 0 511.999 511.999"
-                    xml:space="preserve"
-                  >
-                    <path
-                      style="fill: #ff6465"
-                      d="M384.955,256l120.28-120.28c9.019-9.019,9.019-23.642,0-32.66L408.94,6.765  c-9.019-9.019-23.642-9.019-32.66,0l-120.28,120.28L135.718,6.765c-9.019-9.019-23.642-9.019-32.66,0L6.764,103.058  c-9.019,9.019-9.019,23.642,0,32.66l120.28,120.28L6.764,376.28c-9.019,9.019-9.019,23.642,0,32.66l96.295,96.294  c9.019,9.019,23.642,9.019,32.66,0l120.28-120.28l120.28,120.28c9.019,9.019,23.642,9.019,32.66,0l96.295-96.294  c9.019-9.019,9.019-23.642,0-32.66L384.955,256z"
-                    />
-                  </svg>
+                <div>
+                  <p class="text-small">AAA+</p>
+                  <div class="fail">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      xmlns:xlink="http://www.w3.org/1999/xlink"
+                      width="30px"
+                      height="auto"
+                      viewBox="0 0 511.999 511.999"
+                      style="enable-background: new 0 0 511.999 511.999"
+                      xml:space="preserve"
+                    >
+                      <path
+                        style="fill: #ff6465"
+                        d="M384.955,256l120.28-120.28c9.019-9.019,9.019-23.642,0-32.66L408.94,6.765  c-9.019-9.019-23.642-9.019-32.66,0l-120.28,120.28L135.718,6.765c-9.019-9.019-23.642-9.019-32.66,0L6.764,103.058  c-9.019,9.019-9.019,23.642,0,32.66l120.28,120.28L6.764,376.28c-9.019,9.019-9.019,23.642,0,32.66l96.295,96.294  c9.019,9.019,23.642,9.019,32.66,0l120.28-120.28l120.28,120.28c9.019,9.019,23.642,9.019,32.66,0l96.295-96.294  c9.019-9.019,9.019-23.642,0-32.66L384.955,256z"
+                      />
+                    </svg>
+                  </div>
                 </div>
               </div>
             </div>
             <div class="check-result">
               <div>
                 <p class="text-small">Graphics</p>
-                <div class="pass">Icon</div>
+                <div class="circle-block">
+                  <div>
+                    <p class="text-small">AA+</p>
+                    <div class="pass">Icon</div>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -26,10 +26,6 @@ body {
   color: var(--text-primary);
 }
 
-.letter-spacing {
-  letter-spacing: -0.045em;
-}
-
 section {
   margin-bottom: 4rem;
 }
@@ -56,10 +52,6 @@ footer p {
   text-align: center;
 }
 
-.primary {
-  background-color: var(--primary-section);
-}
-
 .container {
   width: 80%;
   max-width: 1100px;
@@ -67,6 +59,11 @@ footer p {
   padding: 0.25rem 0;
 }
 
+.primary {
+  background-color: var(--primary-section);
+}
+
+// Header text
 .page-title {
   font-size: 2rem;
   font-variation-settings: "wght" 900;
@@ -74,18 +71,16 @@ footer p {
   margin: 4rem 0 1.8rem 0;
 }
 
+.letter-spacing {
+  letter-spacing: -0.045em;
+}
+
 .description {
   color: var(--text-secondary);
   text-align: center;
 }
 
-.large {
-  font-weight: bold;
-  font-size: 2rem;
-  padding: 0;
-  margin: 0;
-}
-
+// input-row
 .inputs-row {
   display: flex;
   flex-direction: column;
@@ -93,37 +88,6 @@ footer p {
   justify-content: center;
   gap: 1rem;
   margin: 4rem 0 1rem 0;
-}
-
-.result-row {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 2rem;
-}
-
-.ratio-result,
-.check-result {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-}
-
-.text-small {
-  font-size: 1.15rem;
-}
-
-.ratio-result {
-  margin-right: 2rem;
-}
-
-.input-items {
-  display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
 .input-fields {
@@ -137,6 +101,12 @@ footer p {
 
 .input-fields label {
   font-size: 1.4rem;
+}
+
+.input-items {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .swatch-one,
@@ -154,6 +124,45 @@ footer p {
 }
 .swatch-two {
   background-color: red;
+}
+
+// result-row and check-result
+.result-row {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.ratio-result,
+.check-result {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+
+.ratio-result {
+  margin-right: 2rem;
+}
+
+.circle-block {
+  display: flex;
+  justify-content: center;
+  gap: 1em;
+}
+
+.text-small {
+  font-size: 1.15rem;
+}
+
+.large {
+  font-weight: bold;
+  font-size: 2rem;
+  padding: 0;
+  margin: 0;
 }
 
 .pass,
@@ -176,6 +185,7 @@ footer p {
   color: var(--fail-border);
 }
 
+// text section styling
 .secondary .container h2 {
   font-variation-settings: "wght" 800;
 }
@@ -221,11 +231,12 @@ small {
 @media (min-width: 768px) {
   .inputs-row {
     flex-direction: row;
-    align-items: flex-end;
+    align-items: center;
     gap: 1rem;
   }
 
-  .input-items {
+  .input-items,
+  .label {
     align-self: center;
   }
 }


### PR DESCRIPTION
# Description

Added the text of `AA+` and `AAA+` to the `results-row` fields. I added 2 div tags and some CSS for the first div. It looks correct on small screens but I can not get the results row to display `flex-direction: row`. I also made comments in the styles.css file and grouped similar rules together. This is **not** a fix for issue 65.
Fixes # (65)

<!-- Please place an x in the [ ] to check off the type of change for this PR -->

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Chore items (this includes basic clean up of files, or updates to packages)
- [ ] Updates to documentation

<!-- Please make sure to go through the entire checklist before requesting a review. Place an x in the [ ] to check off all of the items completed -->

## Checklist

- [x] I have a descriptive title for my PR
- [x] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] I have run the project locally and reviewed the code changes
- [x] My changes generate no new warnings
