### PR TITLE
Add shorthand hex format

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,12 +135,14 @@ const displayResult = () => {
   const hexRegex = /^#([A-Fa-f0-9]{6})$/;
   const hslRegex = /^hsl.*/i;
   const hslaRegex = /^hsla.*/i;
+  const hexRegex3Digit = /^#[a-fA-F0-9]{3}$/;
   if (
     firstColor.length === 7 ||
     rgbRegex.test(firstColor) ||
     rgbaRegex.test(firstColor) ||
     hslRegex.test(firstColor) ||
-    hslaRegex.test(firstColor)
+    hslaRegex.test(firstColor) ||
+    hexRegex3Digit.test(firstColor)
   ) {
     foregroundSwatch.style.backgroundColor = firstColor;
   }
@@ -149,7 +151,8 @@ const displayResult = () => {
     rgbRegex.test(secondColor) ||
     rgbaRegex.test(secondColor) ||
     hslRegex.test(secondColor) ||
-    hslaRegex.test(secondColor)
+    hslaRegex.test(secondColor) ||
+    hexRegex3Digit.test(secondColor)
   ) {
     backgroundSwatch.style.backgroundColor = secondColor;
   }
@@ -173,6 +176,15 @@ const displayResult = () => {
     }
   } else if (firstColor.length < 7 || secondColor.length < 7) {
     ratioResult.innerHTML = "";
+  }
+  if(hexRegex3Digit.test(firstColor) && hexRegex3Digit.test(secondColor)) {
+    firstColor = [...firstColor].map((x, index) => (index != 0) ? x + x: x).join("");
+    secondColor = [...secondColor].map((x, index) => (index != 0) ? x + x: x).join("");
+    ratioResult.innerHTML = colorFormatRatio(
+      firstColor,
+      secondColor,
+      hexToRGB
+    );
   }
   // CASE two RGBAs
   //changed else if to if for two rgba

--- a/index.js
+++ b/index.js
@@ -126,7 +126,9 @@ const colorFormatRatio = (color1, color2, convertRatio) => {
   const RGBColor2 = convertRatio(color2);
   return calculateRatio(RGBColor1, RGBColor2);
 };
-
+const shortToFullHex = (hexColor) => {
+  return [...hexColor].map((x, index) => (index != 0) ? x + x: x).join("");
+}
 const displayResult = () => {
   let firstColor = foregroundColor.value;
   let secondColor = backgroundColor.value;
@@ -178,11 +180,9 @@ const displayResult = () => {
     ratioResult.innerHTML = "";
   }
   if(hexRegex3Digit.test(firstColor) && hexRegex3Digit.test(secondColor)) {
-    firstColor = [...firstColor].map((x, index) => (index != 0) ? x + x: x).join("");
-    secondColor = [...secondColor].map((x, index) => (index != 0) ? x + x: x).join("");
     ratioResult.innerHTML = colorFormatRatio(
-      firstColor,
-      secondColor,
+      shortToFullHex(firstColor),
+      shortToFullHex(secondColor),
       hexToRGB
     );
   }


### PR DESCRIPTION
# Description

<!-- Please include a detailed summary of the changes made. Also please link the issue that this PR is fixing. -->
Added shorthand hex format. This allows users to calculate the contrast ratio for two 3 digit hex code.

close #(77)

<!-- Please place an x in the [ ] to check off the type of change for this PR -->

## Type of change

- [x] New feature (non-breaking change which adds functionality)


<!-- Please make sure to go through the entire checklist before requesting a review. Place an x in the [ ] to check off all of the items completed -->

## Checklist

- [x] I have a descriptive title for my PR
- [x] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] I have run the project locally and reviewed the code changes
- [x] My changes generate no new warnings
