### PR TITLE
fixed: console errors for svg icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
                     xmlns="http://www.w3.org/2000/svg"
                     xmlns:xlink="http://www.w3.org/1999/xlink"
                     width="30px"
-                    height=""
+                    height="100%"
                     viewBox="0 -4 30 30"
                     version="1.1"
                   >
@@ -111,7 +111,7 @@
                     xmlns="http://www.w3.org/2000/svg"
                     xmlns:xlink="http://www.w3.org/1999/xlink"
                     width="30px"
-                    height=""
+                    height="100%"
                     viewBox="0 -4 30 30"
                   >
                     <defs>
@@ -151,7 +151,7 @@
                     xmlns:xlink="http://www.w3.org/1999/xlink"
                     version="1.1"
                     width="30px"
-                    height="auto"
+                    height="100%"
                     viewBox="0 0 511.999 511.999"
                     style="enable-background: new 0 0 511.999 511.999"
                     xml:space="preserve"
@@ -167,7 +167,7 @@
                     xmlns="http://www.w3.org/2000/svg"
                     xmlns:xlink="http://www.w3.org/1999/xlink"
                     width="30px"
-                    height="auto"
+                    height="100%"
                     viewBox="0 0 511.999 511.999"
                     style="enable-background: new 0 0 511.999 511.999"
                     xml:space="preserve"


### PR DESCRIPTION
# Description

I went ahead and did slightly different changes than ones from instructions:

I changed all heights to 100%, as @sparkO7 suggested in discord.

Because with removed heights icons were not aligned properly.

Fixes #89

<!-- Please place an x in the [ ] to check off the type of change for this PR -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore items (this includes basic clean up of files, or updates to packages)
- [ ] Updates to documentation

<!-- Please make sure to go through the entire checklist before requesting a review. Place an x in the [ ] to check off all of the items completed -->

## Checklist

- [x] I have a descriptive title for my PR
- [x] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] I have run the project locally and reviewed the code changes
- [x] My changes generate no new warnings
