### PR TITLE
chore: change placeholder text for foreground input

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Fixes # (issue)
 
 ## Checklist
 
-- [] I have a descriptive title for my PR
-- [] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
-- [] I have run the project locally and reviewed the code changes
-- [] My changes generate no new warnings
+- [ ] I have a descriptive title for my PR
+- [ ] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
+- [ ] I have run the project locally and reviewed the code changes
+- [ ] My changes generate no new warnings

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Fixes # (issue)
 
 ## Checklist
 
-- [x] I have a descriptive title for my PR
-- [x] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
-- [x] I have run the project locally and reviewed the code changes
-- [x] My changes generate no new warnings
+- [] I have a descriptive title for my PR
+- [] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
+- [] I have run the project locally and reviewed the code changes
+- [] My changes generate no new warnings

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Fixes # (issue)
 
 ## Checklist
 
-- [ ] I have a descriptive title for my PR
-- [ ] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
-- [ ] I have run the project locally and reviewed the code changes
-- [ ] My changes generate no new warnings
+- [x] I have a descriptive title for my PR
+- [x] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
+- [x] I have run the project locally and reviewed the code changes
+- [x] My changes generate no new warnings

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
                     id="foreground-color"
                     name="foreground-color"
                     type="text"
-                    placeholder="rgb(255, 255, 255)"
+                    placeholder="#FFFFFF"
                   />
                 </div>
               </div>


### PR DESCRIPTION
Foreground input placeholder was changed from an rgb value to hex code.

# Description

<!-- Please include a detailed summary of the changes made. Also please link the issue that this PR is fixing. -->

Fixes #107 - placeholder text changed from rgb value to hex code

<!-- Please place an x in the [ ] to check off the type of change for this PR -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore items (this includes basic clean up of files, or updates to packages)
- [ ] Updates to documentation

<!-- Please make sure to go through the entire checklist before requesting a review. Place an x in the [ ] to check off all of the items completed -->

## Checklist

- [x] I have a descriptive title for my PR
- [x] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] I have run the project locally and reviewed the code changes
- [x] My changes generate no new warnings
