### PR TITLE
Fix Error message showing up for valid HSL inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,6 +255,7 @@ const displayResult = () => {
   //CASE two HSLs
   else if (hslRegex.test(firstColor) && hslRegex.test(secondColor)) {
     ratioResult.innerHTML = colorFormatRatio(firstColor, secondColor, hslToRGB);
+     hideErrorMessage(warning);
   }
   //CASE two named colors
   else if (isItNamedColor(firstColor) && isItNamedColor(secondColor)) {


### PR DESCRIPTION
# Description
Fixed invalid message showing up when a valid hsl color is inputted 
<!-- Please include a detailed summary of the changes made. Also please link the issue that this PR is fixing. -->

Fixes #119

<!-- Please place an x in the [ ] to check off the type of change for this PR -->

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- Please make sure to go through the entire checklist before requesting a review. Place an x in the [ ] to check off all of the items completed -->

## Checklist

- [x] I have a descriptive title for my PR
- [x] I have linked this PR to the corresponding issue. [See how to do that here.](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] I have run the project locally and reviewed the code changes
- [x] My changes generate no new warnings
